### PR TITLE
OnTrack deployement on GCP

### DIFF
--- a/production/docker-compose.yml
+++ b/production/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       - doubtfire_logs:/doubtfire/log
       - ./shared-files:/shared-files
       - ./shared-files/aliases:/etc/aliases:ro
-    command: /bin/bash -c "bundle exec rails s -b 0.0.0.0"
+    command: /bin/bash -c "rm -f /doubtfire/tmp/pids/server.pid; bundle exec rails s -b 0.0.0.0"
     restart: on-failure:5
 
   # Database server - could be external to docker

--- a/production/shared-files/proxy-nginx.conf
+++ b/production/shared-files/proxy-nginx.conf
@@ -9,25 +9,25 @@ http {
     # and drop www if present
     server {
         listen              80;
-        server_name www.localhost localhost; #update to remove localhost name
-        return 301 https://localhost$request_uri; #replace localhost with domain name of server
+        server_name www.34.129.246.4 34.129.246.4#update to remove localhost name
+        return 301 https://34.129.246.4$request_uri; #replace localhost with domain name of server
     }
 
     # Drop www if present in https connections
     server { # This new server will watch for traffic on 443
         listen              443 ssl;
-        server_name         www.localhost; #replace localhost with domain name of server
+        server_name         www.34.129.246.4; #replace localhost with domain name of server
         ssl_certificate     /etc/nginx/cert.crt;
         ssl_certificate_key /etc/nginx/key.key;
         underscores_in_headers on;
-        return 301 https://localhost$request_uri; #replace localhost with domain name of server
+        return 301 https://34.129.246.4$request_uri; #replace localhost with domain name of server
     }
 
     # We have a direct ssl connection to the domain name...
     # Route requests to internal servers
     server {
         listen              443 ssl;
-        server_name         localhost; #replace localhost with domain name of server
+        server_name         34.129.246.4; #replace localhost with domain name of server
         ssl_certificate     /etc/nginx/cert.crt;
         ssl_certificate_key /etc/nginx/key.key;
 

--- a/production/shared-files/proxy-nginx.conf
+++ b/production/shared-files/proxy-nginx.conf
@@ -9,25 +9,25 @@ http {
     # and drop www if present
     server {
         listen              80;
-        server_name www.34.129.246.4 34.129.246.4#update to remove localhost name
-        return 301 https://34.129.246.4$request_uri; #replace localhost with domain name of server
+        server_name www.34.129.127.168 34.129.127.168#update to remove localhost name
+        return 301 https://34.129.127.168$request_uri; #replace localhost with domain name of server
     }
 
     # Drop www if present in https connections
     server { # This new server will watch for traffic on 443
         listen              443 ssl;
-        server_name         www.34.129.246.4; #replace localhost with domain name of server
+        server_name         www.34.129.127.168; #replace localhost with domain name of server
         ssl_certificate     /etc/nginx/cert.crt;
         ssl_certificate_key /etc/nginx/key.key;
         underscores_in_headers on;
-        return 301 https://34.129.246.4$request_uri; #replace localhost with domain name of server
+        return 301 https://34.129.127.168$request_uri; #replace localhost with domain name of server
     }
 
     # We have a direct ssl connection to the domain name...
     # Route requests to internal servers
     server {
         listen              443 ssl;
-        server_name         34.129.246.4; #replace localhost with domain name of server
+        server_name         34.129.127.168; #replace localhost with domain name of server
         ssl_certificate     /etc/nginx/cert.crt;
         ssl_certificate_key /etc/nginx/key.key;
 


### PR DESCRIPTION
Deploy OnTrack on GCP

Description
Deploy OnTrack on GCP

#Features include:

##Type of change
-[ ] Bug fix (api server does not get started when a cached version of server.pid is available)
-[ ] New feature (Proxy Configuration for GCP account)
-[ ] This change requires a documentation update
-[ ] How Has This Been Tested: Setup has been tested at 2 level 1. On a local machine with localhost setup 2. Created a test vm instance and fixed all the issues on test infra. 
-[ ] Please describe the tests that you ran to verify your changes. Service on GCP is deployed the first time. To test open the following link https://34.129.127.168 in a browser. A certificate warning will be displayed. Also, make sure VM instances on google cloud are up and running.

Testing Checklist:
Tested container deployment successfully

Checklist:
My code follows the style guidelines of this project
I have performed a self-review of my own code
I have made corresponding changes to the documentation
My changes generate no new warnings
