### PR TITLE
docs: Improve production deployment documentation

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -84,7 +84,8 @@ The setups to configure these components include:
 6. Configure email settings:
    - Edit **shared-files/aliases** to map the root user email to the support email address that the application will use.
    - Edit **shared-files/msmtprc** to include the necessary details used to connect to your mail server.
-7. Initialise the database by running:
+7. Access the apiserver docker container by runing the command "docker exec -it <CONTAINER ID> bash" to launch a Bash terminal within the container.
+8. Initialise the database by running the following command within the apiserver docker container:
    - `DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rake db:setup db:init`. When prompted about running in production, respond with `Yes` (case sensitive) to allow the database initialisation to proceed.
    - Verify the database setup in the rails console `bundle exec rails c`, and update username and email to match expected admin user:
 


### PR DESCRIPTION
Improves the deployment documentation slightly to clearly indicate where to run the command to initialise the database within the production deployment.